### PR TITLE
Change the CouchDB configuration with Ansible

### DIFF
--- a/lib/couchdb_config.py
+++ b/lib/couchdb_config.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python
+
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Leif Hanack, Daniel Bechler
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+DOCUMENTATION = '''
+---
+module: couchdb_config
+short_description: Add, update and delete CouchDB configuration keys
+description:
+    - This module allows you to change the CouchDB configuration.
+    - You can add and update section keys, which is equivalent to a PUT /_config/{section}/{key} using the
+    - [CouchDB API](http://docs.couchdb.org/en/latest/api/server/configuration.html#config-section-key).
+    - And you can delete section keys, which is equivalent to a DELETE /_config/{section}/{key}.
+version_added: 1.0
+author: Leif Hanack @leifhanack
+requirements:
+    - pycouchdb 1.13 or above
+    - requests
+options:
+    section:
+        description:
+            - The configuration section name
+        required: true
+    key:
+        description:
+            - The configuration key name
+        required: true
+    value:
+        description:
+            - The configuration value
+        required: when state is present, which is the default
+    state:
+        description:
+            - When state is `present` you must provide a value to add or update a section key.
+            - State `absent` must be provided when you want to delete a section key.
+        required: false
+        default: present
+        choices: [ "present", "absent" ]
+    host:
+        description:
+            - The host running the database
+        required: false
+        default: localhost
+    port:
+        description:
+            - The port to connect to
+        required: false
+        default: 5984
+    user:
+        description:
+            - The administrator user used to authenticate with
+        required: false
+    password:
+        description:
+            - The administrator password of the user
+        required: false
+'''
+
+EXAMPLES = '''
+# setting multiple values
+- couchdb_config:
+    section: '{{ item.section }}'
+    key: '{{ item.key }}'
+    value: '{{ item.value }}'
+  with_items:
+    - { section: couch_httpd_auth, key: timeout, value: 60 }
+    - { section: socket_keys, key: worker_batch_size, value: 510 }
+
+# setting a list of tuples
+- couchdb_config: >
+    section=httpd
+    key=socket_keys
+    value='[{recbuf, 262140}, {sndbuf, 262140}]'
+
+# setting a value when CouchDB is secured
+- couchdb_config:
+    user: admina
+    password: @dm1na
+    section: couch_httpd_auth
+    key: timeout
+    value: 60
+
+# changing host and port
+- couchdb_config: >
+    host=192.168.33.100
+    port=5985
+    section=couch_httpd_auth
+    key=timeout
+    value=60
+
+# delete a section key
+- couchdb_config:
+    section: couch_httpd_auth
+    key: timeout
+    state: absent
+'''
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+IS_INSTALLED_PYCOUCHDB = True
+try:
+    import pycouchdb
+    from pycouchdb.resource import Resource
+    from pycouchdb.exceptions import Conflict, NotFound, BadRequest, AuthenticationFailed
+except ImportError:
+    IS_INSTALLED_PYCOUCHDB = False
+    pycouchdb = None
+    Resource = None
+    Conflict = None
+    NotFound = None
+    BadRequest = None
+    AuthenticationFailed = None
+
+IS_INSTALLED_REQUESTS = True
+try:
+    import requests
+    from requests.exceptions import ConnectionError
+except ImportError:
+    IS_INSTALLED_REQUESTS = False
+    requests = None
+    ConnectionError = None
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            host=dict(default='localhost'),
+            port=dict(type='int', default=5984),
+            user=dict(type='str'),
+            password=dict(type='str', no_log=True),
+            section=dict(type='str', required=True),
+            key=dict(type='str', required=True),
+            value=dict(type='str'),
+            state=dict(type='str', default='present', choices=['absent', 'present']),
+        )
+    )
+
+    if not IS_INSTALLED_PYCOUCHDB:
+        module.fail_json(msg='Please install pycouchdb 1.13 or above.')
+
+    if version_tuple(pycouchdb.__version__) < version_tuple('1.13'):
+        module.fail_json(msg='pycouchdb version must be 1.13 or above!')
+
+    if not IS_INSTALLED_REQUESTS:
+        module.fail_json(msg='Please install requests')
+
+    couchdb_uri = create_couchdb_uri(module.params['host'], module.params['port'],
+                                     user=module.params['user'], password=module.params['password'])
+
+    section = module.params['section']
+    key = module.params['key']
+    value = module.params['value']
+    state = module.params['state']
+
+    try:
+        if state == "present":
+            if value is None:
+                module.fail_json(msg='Failed. Please specify a value')
+            is_changed = update_configuration_key(couchdb_uri, section, key, value)
+        if state == "absent":
+            is_changed = delete_configuration_key(couchdb_uri, section, key)
+    except ConnectionError:
+        module.fail_json(msg='Failed to connect to ' + couchdb_uri)
+    except AuthenticationFailed:
+        module.fail_json(msg='Failed to authenticate')
+    except Conflict:
+        module.fail_json(msg='Failed with conflicts')
+    except NotFound:
+        module.fail_json(msg='Requested resource is not found')
+    except BadRequest:
+        module.fail_json(msg='Bad request, maybe your values are not a not valid JSON strings')
+    except RuntimeError:
+        module.fail_json(msg='Unexpected error, maybe your authentication method is invalid')
+
+    kwargs = {}
+    module.exit_json(changed=is_changed, **kwargs)
+
+
+def create_couchdb_uri(host, port, user=None, password=None):
+    if user is not None:
+        auth = '{0}:{1}@'.format(user, password)
+    else:
+        auth = ''
+
+    return ''.join(['http://', auth, host, ':{0}'.format(port)])
+
+
+def update_configuration_key(uri, section, key, value):
+    response = Resource(uri).put('_config/{0}/{1}'.format(section, key), data=json.dumps(value))
+    if response is not None and response[1] == value:
+        is_changed = False
+    else:
+        is_changed = True
+    return is_changed
+
+
+def delete_configuration_key(uri, section, key):
+    response = Resource(uri).delete('_config/{0}/{1}'.format(section, key))
+    result = json.loads(response[1])
+    if type(result) is dict and 'error' in result:
+        is_changed = False
+    else:
+        is_changed = True
+    return is_changed
+
+
+def version_tuple(version):
+    return tuple(map(int, (version.split("."))))
+
+from ansible.module_utils.basic import *
+main()

--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,7 +1,8 @@
-FROM python:2.7-alpine
+FROM python:2.7-slim
 RUN mkdir -p /ci/test/integration
 WORKDIR /ci/test/integration
-RUN apk update && apk add gcc libc-dev
+RUN apt-get update && apt-get install -y gcc libc-dev
 COPY requirements.txt /
 RUN pip install --upgrade -r /requirements.txt
 CMD [ "ansible-playbook", "-i", "inventory", "playbook.yml" ]
+COPY . /ci

--- a/test/integration/playbook_test_couchdb_config.yml
+++ b/test/integration/playbook_test_couchdb_config.yml
@@ -9,5 +9,4 @@
       fail: msg="Expected to run tests against Python 2.7 but found {{ ansible_python_version }}"
       when: not ansible_python_version|match('2\.7\.[0-9]+')
   roles:
-    - test_couchdb_user
     - test_couchdb_config

--- a/test/integration/requirements.txt
+++ b/test/integration/requirements.txt
@@ -8,3 +8,4 @@ pycrypto==2.6.1
 PyYAML==3.11
 requests==2.9.1
 wheel==0.26.0
+pycouchdb==1.14

--- a/test/integration/roles/test_couchdb_config/defaults/main.yml
+++ b/test/integration/roles/test_couchdb_config/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+couchdb_host: couchdb
+admin_name: ali
+admin_password: allright
+user_name: ulli
+user_password: ullberg

--- a/test/integration/roles/test_couchdb_config/tasks/__create_admin.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/__create_admin.yml
@@ -1,0 +1,8 @@
+---
+- name: create admin
+  couchdb_user: >
+    host={{ couchdb_host }}
+    name={{ admin_name }}
+    password={{ admin_password }}
+    admin=yes
+    state=present

--- a/test/integration/roles/test_couchdb_config/tasks/__remove_admin.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/__remove_admin.yml
@@ -1,0 +1,9 @@
+---
+- name: remove admin
+  couchdb_user: >
+    host={{ couchdb_host }}
+    name={{ admin_name }}
+    admin=yes
+    state=absent
+    login_user={{ admin_name }}
+    login_password={{ admin_password }}

--- a/test/integration/roles/test_couchdb_config/tasks/delete_config_key/secured_db_admin_should_be_able_to_delete_key.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/delete_config_key/secured_db_admin_should_be_able_to_delete_key.yml
@@ -1,0 +1,50 @@
+---
+- include: ../__create_admin.yml
+
+- name: admin adds a key
+  couchdb_config:
+    host: '{{ couchdb_host }}'
+    user: '{{ admin_name }}'
+    password: '{{ admin_password }}'
+    section: couch_httpd_auth
+    key: timeout
+    value: 42
+  register: result
+
+- name: fetch config
+  uri:
+    url: http://{{ couchdb_host }}:5984/_config
+    user: "{{ admin_name }}"
+    password: "{{ admin_password }}"
+    force_basic_auth: yes
+    return_content: yes
+    HEADER_Accept: application/json
+  register: result
+
+- name: assert that precondition is met
+  assert: { that: "result.json.couch_httpd_auth.has_key('timeout')" }
+
+- name: admin deletes key
+  couchdb_config:
+    host: '{{ couchdb_host }}'
+    user: '{{ admin_name }}'
+    password: '{{ admin_password }}'
+    section: couch_httpd_auth
+    key: timeout
+    state: absent
+  register: result
+
+- name: fetch config
+  uri:
+    url: http://{{ couchdb_host }}:5984/_config
+    user: "{{ admin_name }}"
+    password: "{{ admin_password }}"
+    force_basic_auth: yes
+    return_content: yes
+    HEADER_Accept: application/json
+  register: result
+
+- name: assert that key is no longer present
+  assert: { that: "result.json.couch_httpd_auth.has_key('timeout') == False" }
+
+- include: ../__remove_admin.yml

--- a/test/integration/roles/test_couchdb_config/tasks/delete_config_key/secured_db_user_should_not_be_able_to_delete_key.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/delete_config_key/secured_db_user_should_not_be_able_to_delete_key.yml
@@ -1,0 +1,21 @@
+---
+- include: ../__create_admin.yml
+
+- name: user should not be able to delete key
+  couchdb_config:
+    host: '{{ couchdb_host }}'
+    user: '{{ user_name }}'
+    password: '{{ user_password }}'
+    section: couch_httpd_auth
+    key: timeout
+    state: absent
+  register: result
+  ignore_errors: yes
+
+- name: url
+  debug: msg="result => {{ result }}"
+
+- name: assert failure when not an admin
+  assert: { that: "'unauthorized' in result.exception" }
+
+- include: ../__remove_admin.yml

--- a/test/integration/roles/test_couchdb_config/tasks/delete_config_key/should_delete_key.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/delete_config_key/should_delete_key.yml
@@ -1,0 +1,36 @@
+---
+- name: add a key
+  couchdb_config:
+    host: '{{ couchdb_host }}'
+    section: couch_httpd_auth
+    key: timeout
+    value: 42
+  register: result
+
+- name: fetch config
+  uri:
+    url: http://{{ couchdb_host }}:5984/_config
+    return_content: yes
+    HEADER_Accept: application/json
+  register: result
+
+- name: assert that precondition is met
+  assert: { that: "result.json.couch_httpd_auth.has_key('timeout')" }
+
+- name: delete key
+  couchdb_config:
+    host: '{{ couchdb_host }}'
+    section: couch_httpd_auth
+    key: timeout
+    state: absent
+  register: result
+
+- name: fetch config
+  uri:
+    url: http://{{ couchdb_host }}:5984/_config
+    return_content: yes
+    HEADER_Accept: application/json
+  register: result
+
+- name: assert that key is no longer present
+  assert: { that: "result.json.couch_httpd_auth.has_key('timeout') == False" }

--- a/test/integration/roles/test_couchdb_config/tasks/delete_config_key/should_fail_when_key_not_found.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/delete_config_key/should_fail_when_key_not_found.yml
@@ -1,0 +1,51 @@
+---
+- name: add a key
+  couchdb_config:
+    host: '{{ couchdb_host }}'
+    section: couch_httpd_auth
+    key: timeout
+    value: 42
+  register: result
+
+- name: fetch config
+  uri:
+    url: http://{{ couchdb_host }}:5984/_config
+    return_content: yes
+    HEADER_Accept: application/json
+  register: result
+
+- name: assert that precondition is met
+  assert: { that: "result.json.couch_httpd_auth.has_key('timeout')" }
+
+- name: delete key
+  couchdb_config:
+    host: '{{ couchdb_host }}'
+    section: couch_httpd_auth
+    key: timeout
+    state: absent
+  register: result
+
+- name: fetch config
+  uri:
+    url: http://{{ couchdb_host }}:5984/_config
+    return_content: yes
+    HEADER_Accept: application/json
+  register: result
+
+- name: assert that key is no longer present
+  assert: { that: "result.json.couch_httpd_auth.has_key('timeout') == False" }
+
+- name: try to delete key which is already deleted
+  couchdb_config:
+    host: '{{ couchdb_host }}'
+    section: couch_httpd_auth
+    key: timeout
+    state: absent
+  register: result
+  ignore_errors: yes
+
+- name: assert failure when key is not found
+  assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'Requested resource is not found'"

--- a/test/integration/roles/test_couchdb_config/tasks/main.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+# ===============================================
+# Tests around deleting keys from the configuration
+#
+
+- include: delete_config_key/secured_db_admin_should_be_able_to_delete_key.yml
+- include: delete_config_key/secured_db_user_should_not_be_able_to_delete_key.yml
+
+- include: delete_config_key/should_delete_key.yml
+- include: delete_config_key/should_fail_when_key_not_found.yml
+
+
+# ===============================================
+# Tests around updating the configuration
+#
+
+- include: update_config_key/secured_db_admin_should_be_able_to_change_multiple_config_values.yml
+- include: update_config_key/secured_db_admin_should_be_able_to_change_config.yml
+- include: update_config_key/secured_db_user_should_not_be_able_to_change_config.yml
+
+- include: update_config_key/should_change_config_when_omitting_quotes.yml
+- include: update_config_key/should_fail_when_couchdb_is_not_connectable.yml
+- include: update_config_key/should_change_config_with_multiple_keys.yml
+- include: update_config_key/should_change_config_with__single_value__key.yml
+- include: update_config_key/should_change_config_with__tuple__key.yml
+- include: update_config_key/should_change_config_with__list_of_tuples__key.yml
+- include: update_config_key/should_change_config_with__list__key.yml
+- include: update_config_key/should_change_config_with__string_containing_spaces__key.yml
+- include: update_config_key/should_change_config_with_key_containing_quotes.yml
+- include: update_config_key/should_report_no_change_when_setting_then_same_value_twice.yml
+- include: update_config_key/change_config_should_fail_when_value_is_missing.yml

--- a/test/integration/roles/test_couchdb_config/tasks/update_config_key/change_config_should_fail_when_value_is_missing.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/update_config_key/change_config_should_fail_when_value_is_missing.yml
@@ -1,0 +1,11 @@
+---
+- name: change config should fail when value is missing
+  couchdb_config:
+    host: '{{ couchdb_host }}'
+    section: replicator
+    key: connection_timeout
+  register: result
+  ignore_errors: yes
+
+- name: assert failure when value is missing
+  assert: { that: "result.msg == 'Failed. Please specify a value'" }

--- a/test/integration/roles/test_couchdb_config/tasks/update_config_key/secured_db_admin_should_be_able_to_change_config.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/update_config_key/secured_db_admin_should_be_able_to_change_config.yml
@@ -1,0 +1,30 @@
+---
+- include: ../__create_admin.yml
+
+- name: admin should be able to change config
+  couchdb_config:
+    host: '{{ couchdb_host }}'
+    user: '{{ admin_name }}'
+    password: '{{ admin_password }}'
+    section: 'couch_httpd_auth'
+    key: timeout
+    value: 53
+  register: result
+
+- name: assert that module reports change
+  assert: { that: "result.changed == true" }
+
+- name: fetch config
+  uri:
+    url: http://{{ couchdb_host }}:5984/_config
+    user: "{{ admin_name }}"
+    password: "{{ admin_password }}"
+    force_basic_auth: yes
+    return_content: yes
+    HEADER_Accept: application/json
+  register: result
+
+- name: assert that config can set single value (e.g. '53')
+  assert: { that: "result.json.couch_httpd_auth.timeout == '53'" }
+
+- include: ../__remove_admin.yml

--- a/test/integration/roles/test_couchdb_config/tasks/update_config_key/secured_db_admin_should_be_able_to_change_multiple_config_values.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/update_config_key/secured_db_admin_should_be_able_to_change_multiple_config_values.yml
@@ -1,0 +1,42 @@
+---
+- include: ../__create_admin.yml
+
+- name: admin should be able to change multiple config values
+  couchdb_config:
+    host: '{{ couchdb_host }}'
+    user: '{{ admin_name }}'
+    password: '{{ admin_password }}'
+    section: "{{ item.section }}"
+    key: "{{ item.key }}"
+    value: "{{ item.value }}"
+  with_items:
+    - { section: 'compactions', key: '_default', value: '[{db_fragmentation, "51%"}, {view_fragmentation, "51%"}]' }
+    - { section: 'log', key: 'level', value: 'info' }
+    - { section: 'httpd', key: 'socket_options', value: '[{recbuf, 262155}, {sndbuf, 262155}, {nodelay, true}]' }
+  register: result
+
+- name: assert that module reports change
+  assert: { that: "result.changed == true" }
+
+- name: fetch config
+  uri:
+    url: http://{{ couchdb_host }}:5984/_config
+    user: "{{ admin_name }}"
+    password: "{{ admin_password }}"
+    force_basic_auth: yes
+    return_content: yes
+    HEADER_Accept: application/json
+  register: result
+
+- name: assert multiple changes were applied
+  assert:
+    that:
+      - "result.json.compactions._default == '[{db_fragmentation, \"51%\"}, {view_fragmentation, \"51%\"}]'"
+      - "result.json.log.level == 'info'"
+      - "result.json.httpd.socket_options == '[{recbuf, 262155}, {sndbuf, 262155}, {nodelay, true}]'"
+
+- include: ../__remove_admin.yml
+
+
+
+

--- a/test/integration/roles/test_couchdb_config/tasks/update_config_key/secured_db_user_should_not_be_able_to_change_config.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/update_config_key/secured_db_user_should_not_be_able_to_change_config.yml
@@ -1,0 +1,21 @@
+---
+- include: ../__create_admin.yml
+
+- name: user should not be able to change config
+  couchdb_config: >
+    host={{ couchdb_host }}
+    user={{ user_name }}
+    password={{ user_password }}
+    section='couch_httpd_auth'
+    key='timeout'
+    value='53'
+  register: result
+  ignore_errors: yes
+
+- name: url
+  debug: msg="result => {{ result }}"
+
+- name: assert failure when not an admin
+  assert: { that: "'unauthorized' in result.exception" }
+
+- include: ../__remove_admin.yml

--- a/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_change_config_when_omitting_quotes.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_change_config_when_omitting_quotes.yml
@@ -1,0 +1,21 @@
+---
+- name: should change config with single value key
+  couchdb_config:
+    host: '{{ couchdb_host }}'
+    section: couch_httpd_auth
+    key: timeout
+    value: 44
+  register: result
+
+- name: assert that module reports change
+  assert: { that: "result.changed == true" }
+
+- name: fetch config
+  uri:
+    url: http://{{ couchdb_host }}:5984/_config
+    return_content: yes
+    HEADER_Accept: application/json
+  register: result
+
+- name: assert that config can set single value (e.g. 44)
+  assert: { that: "result.json.couch_httpd_auth.timeout == '44'" }

--- a/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_change_config_with__list__key.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_change_config_with__list__key.yml
@@ -1,0 +1,21 @@
+---
+- name: should change config with list key
+  couchdb_config: >
+    host={{ couchdb_host }}
+    section='stats'
+    key='samples'
+    value='[0, 61, 301, 901]'
+  register: result
+
+- name: assert that module reports change
+  assert: { that: "result.changed == true" }
+
+- name: fetch config
+  uri:
+    url: http://{{ couchdb_host }}:5984/_config
+    return_content: yes
+    HEADER_Accept: application/json
+  register: result
+
+- name: assert that config can set list (e.g. '[0, 61, 301, 901]')
+  assert: { that: "result.json.stats.samples == '[0, 61, 301, 901]'" }

--- a/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_change_config_with__list_of_tuples__key.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_change_config_with__list_of_tuples__key.yml
@@ -1,0 +1,21 @@
+---
+- name: should change config with list of tuples key
+  couchdb_config: >
+    host={{ couchdb_host }}
+    section='httpd'
+    key='socket_keys'
+    value='[{recbuf, 262143}, {sndbuf, 262143}]'
+  register: result
+
+- name: assert that module reports change
+  assert: { that: "result.changed == true" }
+
+- name: fetch config
+  uri:
+    url: http://{{ couchdb_host }}:5984/_config
+    return_content: yes
+    HEADER_Accept: application/json
+  register: result
+
+- name: assert that config can set list of tuples (e.g. '[{recbuf, 262143}, {sndbuf, 262143}]')
+  assert: { that: "result.json.httpd.socket_keys == '[{recbuf, 262143}, {sndbuf, 262143}]'" }

--- a/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_change_config_with__single_value__key.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_change_config_with__single_value__key.yml
@@ -1,0 +1,21 @@
+---
+- name: should change config with single value key
+  couchdb_config: >
+    host={{ couchdb_host }}
+    section='couch_httpd_auth'
+    key='timeout'
+    value='53'
+  register: result
+
+- name: assert that module reports change
+  assert: { that: "result.changed == true" }
+
+- name: fetch config
+  uri:
+    url: http://{{ couchdb_host }}:5984/_config
+    return_content: yes
+    HEADER_Accept: application/json
+  register: result
+
+- name: assert that config can set single value (e.g. '53')
+  assert: { that: "result.json.couch_httpd_auth.timeout == '53'" }

--- a/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_change_config_with__string_containing_spaces__key.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_change_config_with__string_containing_spaces__key.yml
@@ -1,0 +1,22 @@
+---
+- name: should change config with string containing spaces key
+  couchdb_config: >
+    host={{ couchdb_host }}
+    section='query_servers'
+    key='coffeescript'
+    value='/usr/foo/bin/couchjs /usr/foo/share/couchdb/server/main-coffee.js'
+  register: result
+
+- name: assert that module reports change
+  assert: { that: "result.changed == true" }
+
+- name: fetch config
+  uri:
+    url: http://{{ couchdb_host }}:5984/_config
+    return_content: yes
+    HEADER_Accept: application/json
+  register: result
+
+- name: assert that config can set string with spaces (e.g. '/usr/foo/bin/couchjs /usr/foo/share/couchdb/server/main-coffee.js')
+  assert: { that: "result.json.query_servers.coffeescript == '/usr/foo/bin/couchjs /usr/foo/share/couchdb/server/main-coffee.js'" }
+

--- a/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_change_config_with__tuple__key.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_change_config_with__tuple__key.yml
@@ -1,0 +1,21 @@
+---
+- name: should change config with tuple key
+  couchdb_config: >
+    host={{ couchdb_host }}
+    section='httpd'
+    key='default_handler'
+    value='{couch_httpd_db, handle_request, foo_bar}'
+  register: result
+
+- name: assert that module reports change
+  assert: { that: "result.changed == true" }
+
+- name: fetch config
+  uri:
+    url: http://{{ couchdb_host }}:5984/_config
+    return_content: yes
+    HEADER_Accept: application/json
+  register: result
+
+- name: assert that config can set tuple (e.g. '{couch_httpd_db, handle_request, foo_bar}')
+  assert: { that: "result.json.httpd.default_handler == '{couch_httpd_db, handle_request, foo_bar}'" }

--- a/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_change_config_with_key_containing_quotes.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_change_config_with_key_containing_quotes.yml
@@ -1,0 +1,21 @@
+---
+- name: should change config with key containing quotes
+  couchdb_config: >
+    host={{ couchdb_host }}
+    section='compactions'
+    key='_default'
+    value='[{db_fragmentation, \"50%\"}, {view_fragmentation, \"50%\"}]'
+  register: result
+
+- name: assert that module reports change
+  assert: { that: "result.changed == true" }
+
+- name: fetch config
+  uri:
+    url: http://{{ couchdb_host }}:5984/_config
+    return_content: yes
+    HEADER_Accept: application/json
+  register: result
+
+- name: assert that config can set string with quotes (e.g. '[{db_fragmentation, \"50%\"}, {view_fragmentation, \"50%\"}]')
+  assert: { that: "result.json.compactions._default == '[{db_fragmentation, \"50%\"}, {view_fragmentation, \"50%\"}]'" }

--- a/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_change_config_with_multiple_keys.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_change_config_with_multiple_keys.yml
@@ -1,0 +1,26 @@
+---
+- name: should change config with multiple keys
+  couchdb_config: >
+    host={{ couchdb_host }}
+    section={{ item.section }}
+    key={{ item.key }}
+    value={{ item.value }}
+  with_items:
+    - { section: 'couch_httpd_auth', key: 'timeout', value: '51' }
+    - { section: 'socket_keys', key: 'worker_batch_size', value: '501' }
+  register: result
+
+- name: assert that module reports change
+  assert: { that: "result.changed == true" }
+
+- name: fetch config
+  uri:
+    url: http://{{ couchdb_host }}:5984/_config
+    return_content: yes
+    HEADER_Accept: application/json
+  register: result
+
+- name: assert that config can set key 1
+  assert: { that: "result.json.couch_httpd_auth.timeout == '51'" }
+- name: assert that config can set key 2
+  assert: { that: "result.json.socket_keys.worker_batch_size == '501'" }

--- a/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_fail_when_couchdb_is_not_connectable.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_fail_when_couchdb_is_not_connectable.yml
@@ -1,0 +1,13 @@
+---
+- name: should fail when couchdb is not connectable
+  couchdb_config: >
+    host=127.0.0.1
+    port=33333
+    section='stats'
+    key='samples'
+    value='[0, 61, 301, 901]'
+  register: result
+  ignore_errors: yes
+
+- name: assert failure when couchdb is not connectable
+  assert: { that: "result.msg == 'Failed to connect to http://127.0.0.1:33333'" }

--- a/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_report_no_change_when_setting_then_same_value_twice.yml
+++ b/test/integration/roles/test_couchdb_config/tasks/update_config_key/should_report_no_change_when_setting_then_same_value_twice.yml
@@ -1,0 +1,22 @@
+---
+- name: should report no change when setting then same value twice
+  couchdb_config:
+    host: '{{ couchdb_host }}'
+    section: couch_httpd_auth
+    key: timeout
+    value: 661
+  register: result
+
+- name: assert that module reports change
+  assert: { that: "result.changed == true" }
+
+- name: setting then same value twice
+  couchdb_config:
+    host: '{{ couchdb_host }}'
+    section: couch_httpd_auth
+    key: timeout
+    value: 661
+  register: result
+
+- name: assert that module reports no change
+  assert: { that: "result.changed == false" }


### PR DESCRIPTION
This module allows you to change the CouchDB configuration with Ansible.

It depends on [py-couchdb](https://github.com/histrio/py-couchdb) and [requests](https://github.com/kennethreitz/requests).

Sample usage:

```
- couchdb_config: >
    section={{ item.section }}
    key={{ item.key }}
    value={{ item.value }}
  with_items:
    - { section: 'couch_httpd_auth', key: 'timeout', value: '60' }
    - { section: 'socket_keys', key: 'worker_batch_size', value: '510' }
```

For more details on how to use this module please take a look at the documentation and examples in  `lib/couchdb_config.py`.

To run the test of this module only, please go to `test/integration` and run

```
docker-compose run --rm tests ansible-playbook -i inventory playbook_test_couchdb_config.yml
```

Before you rerun the tests clean up the setting with

```
docker-compose stop && docker-compose rm -f
```
